### PR TITLE
Pull ktgbotapi transitively from ktgbotapi-commons

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,11 +11,8 @@ repositories {
     maven("https://jitpack.io")
 }
 
-val ktgbotapiVersion = "35.1.0"
-
 dependencies {
-    implementation("dev.inmo:tgbotapi:$ktgbotapiVersion")
-    implementation("com.github.centralhardware:ktgbotapi-commons:3b24b76e")
+    implementation("com.github.centralhardware:ktgbotapi-commons:4db3d261")
     implementation("org.json:json:20260522")
     implementation("io.github.crackthecodeabhi:kreds:0.9.1")
     implementation("org.postgresql:postgresql:42.7.12")


### PR DESCRIPTION
Drops the redundant direct `dev.inmo:tgbotapi` dependency and pulls it transitively from `ktgbotapi-commons` (bumped to 4db3d261, which brings ktgbotapi 35.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)